### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setuptools.setup(
     version="0.1.2",
     author="Dav0815",
     description="Get transport information from TransportNSW",
+    license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Dav0815/TransportNSW",


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.